### PR TITLE
chore: enable dependabot for go and GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Maintain dependencies for Go
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Lets give Dependabot a try :-)

Close #3 

Inspired from: https://github.com/kubernetes-sigs/controller-runtime/blob/master/.github/dependabot.yml