### PR TITLE
refactor(ci): split build workflow in lint/test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,25 @@
+---
+name: CI
 on:
   - pull_request
 jobs:
-  lint-test-build-package:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
           cache: true
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: go.mod
+          cache: true
       - run: go test -v ./...


### PR DESCRIPTION
This will allow the lint and test jobs to run in parallel, as recommended by [golangci-lint-action](https://github.com/golangci/golangci-lint-action#how-to-use).
