### PR TITLE
ci: add initial release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+---
+name: Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cycjimmy/semantic-release-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,12 @@
+---
+branches:
+  - name: main
+# TODO: Remove; Might be useful to have some debug when attempting the first releases
+debug: true
+# TODO: Remove; Attempt a dry run release before a real one
+dryRun: true
+plugins:
+  - - @semantic-release/commit-analyzer
+    - preset: conventionalcommits
+  - @semantic-release/release-notes-generator
+  - @semantic-release/github


### PR DESCRIPTION
This is an initial attempt to create a release workflow. Proposing to run in dry run mode and with debug enabled until we know that we have something that might work.

Close #10 