### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@statnett/stas


### PR DESCRIPTION
This should make PRs get auto-assigned reviewers. We could fine-grain the configuration later if we want to.