### PR TITLE
fix(ci): correct syntax error in .releaserc.yml

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -6,7 +6,7 @@ debug: true
 # TODO: Remove; Attempt a dry run release before a real one
 dryRun: true
 plugins:
-  - - @semantic-release/commit-analyzer
+  - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
-  - @semantic-release/release-notes-generator
-  - @semantic-release/github
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"


### PR DESCRIPTION
Fix initial syntax errors, ref. https://github.com/statnett/controller-runtime-viper/actions/runs/3633773271/jobs/6131166197