### PR TITLE
ci: make semantic-release work

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -6,7 +6,6 @@ debug: true
 # TODO: Remove; Attempt a dry run release before a real one
 dryRun: true
 plugins:
-  - - "@semantic-release/commit-analyzer"
-    - preset: conventionalcommits
+  - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - "@semantic-release/github"


### PR DESCRIPTION
It seems like the default preset handles our conventional commits correctly. I have tested this on my fork - which I should have done from the beginning.