### PR TITLE
ci: add yamllint to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   - pull_request
 jobs:
-  lint:
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,6 +14,11 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
+  yaml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ibiqlik/action-yamllint@v3
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+extends: default
+rules:
+  document-start: disable
+  line-length:
+    max: 120
+    allow-non-breakable-inline-mappings: true
+  truthy:
+    check-keys: false


### PR DESCRIPTION
This adds yamllint to our CI to ensure YAML-files are properly formatted.