### PR TITLE
fix(ci): add comments rule to forgo double space requirement

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -6,3 +6,5 @@ rules:
     allow-non-breakable-inline-mappings: true
   truthy:
     check-keys: false
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
yamllinter expects double spaces before comments, this patch adds an exception for yamllinter to allow single space.
