### PR TITLE
ci: replace GITHUB_TOKEN with PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
       - uses: cycjimmy/semantic-release-action@8f6ceb9d5aae5578b1dcda6af00008235204e7fa # v3.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.STAS_RELEASE_TOKEN }}


### PR DESCRIPTION
I hope replacing the default GITHIB_TOKEN with a fine-grained personal access token (PAT) will fix the release issue of creating protected tags. Example: https://github.com/statnett/controller-runtime-viper/actions/runs/3715017150/jobs/6299673134

![image](https://user-images.githubusercontent.com/1142578/208180608-61bba069-d39b-453f-8a89-22d7e576971f.png)

