### PR TITLE
ci: use PAT to perform checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          token: ${{ secrets.STAS_RELEASE_TOKEN }}
       - uses: cycjimmy/semantic-release-action@8f6ceb9d5aae5578b1dcda6af00008235204e7fa # v3.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.STAS_RELEASE_TOKEN }}


### PR DESCRIPTION
I have a feeling we need to use the PAT added in https://github.com/statnett/controller-runtime-viper/pull/31 to checkout in the release workflow.

Closes #32 (I hope)