### PR TITLE
ci(release): make Dependabot dependency updates trigger patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,12 @@ updates:
     directory: /
     schedule:
       interval: daily
-
+    commit-message:
+      prefix: build
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-permissions:  # added using https://github.com/step-security/secure-workflows
+permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
@@ -22,5 +22,8 @@ jobs:
         with:
           token: ${{ secrets.STAS_RELEASE_TOKEN }}
       - uses: cycjimmy/semantic-release-action@8f6ceb9d5aae5578b1dcda6af00008235204e7fa # v3.2.0
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.STAS_RELEASE_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,21 @@ branches:
 # TODO: Remove; Might be useful to have some debug when attempting the first releases
 debug: true
 plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
+      presetConfig:
+        types:
+          - type: feat
+            section: Features
+          - type: fix
+            section: Bug Fixes
+          - type: build
+            scope: deps
+            section: Dependencies
   - "@semantic-release/github"


### PR DESCRIPTION
By default, only fix/feat/BREAKING triggers a new semantic release. I think Go dependency updates also deserve a new release. This PR slightly modifies the Dependabot configuration so that Go dependency update PR should be prefixed with `build(deps):`. Then configures the semantic-release release configuration to trigger releases for those commits, and includes dependency updates in a separate section of the release notes.

Inspired by https://mattbun.io/posts/semantic-release-dependabot/, and tested in https://github.com/erikgb/test-ci-release.