### PR TITLE
ci: make Dependabot include scope in PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: daily
     commit-message:
       prefix: build
+      include: scope
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: /
@@ -14,3 +15,4 @@ updates:
       interval: weekly
     commit-message:
       prefix: ci
+      include: scope


### PR DESCRIPTION
After modifying the Dependabot commit message, I notice that the PR title does not include scope. This will hopefully fix this.