### PR TITLE
ci: run CI workflow on push to default branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,12 @@
 ---
 name: CI
 on:
-  - pull_request
+  pull_request: {}
+  push:
+    branches:
+      - main
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
-
 jobs:
   golangci-lint:
     permissions:


### PR DESCRIPTION
To be able to add a build badge, and ensure that the build is passing on the default branch, this PR adds push to the default branch as a new CI workflow event.