### PR TITLE
chore: introduce prow-github-actions

### DIFF
--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -1,3 +1,4 @@
+---
 name: Handle prow slash commands
 on:
   issue_comment:

--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -1,0 +1,17 @@
+name: Handle prow slash commands
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  issues: write
+  pull-requests: write
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@f4d01dd4b13f289014c23fe5a19878a2479cb35b # v1.1.3
+        with:
+          prow-commands: |
+            /approve
+            /lgtm
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is an introduction to https://github.com/jpmcb/prow-github-actions, which will allow us to use the most basic slash commands. We'll see how it works and eventually configure more features later.