### PR TITLE
ci: cancel obsolete/redundant workflow automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+concurrency:
+  group: ${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 concurrency:
-  group: ${{ github.head_ref || github.ref }}
+  group: codeql-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
     branches: ["main"]
   schedule:
     - cron: "0 0 * * 1"
+concurrency:
+  group: ${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 jobs:


### PR DESCRIPTION
This will allow workflows for subsequent commits to just keep the latest. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency for details.