### PR TITLE
ci: no need to lint PR when code updated

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -5,7 +5,6 @@ on:
     types:
       - opened
       - edited
-      - synchronize
 permissions: # added using https://github.com/step-security/secure-workflows
   contents: read
 jobs:


### PR DESCRIPTION
The PR linting is currently only checking the PR title, so I think it is sufficient to run the workflow on the PR `opened` and `edited` events.