### PR TITLE
fix: default encoder is dependent on dev-mode

### DIFF
--- a/pkg/zap/zap.go
+++ b/pkg/zap/zap.go
@@ -141,13 +141,13 @@ func stringToLevelEnablerHookFunc() mapstructure.DecodeHookFuncType {
 	return func(in reflect.Type, out reflect.Type, val interface{}) (interface{}, error) {
 		if in.Kind() == reflect.String && out == levelEnablerType {
 			sVal := val.(string)
-			// return nil if ZAP_LOG_LEVEL is not set, crzap lib sets the default value
 			if sVal == "" {
 				var v zapcore.LevelEnabler
+				// return nil if level is not set; controller-runtime sets the default value
 				return &v, nil
 			}
 
-			// ZAP_LOG_LEVEL supports setting of integer value > 0 in addition to `info`, `error` or `debug`
+			// level supports setting of integer value > 0 in addition to `info`, `error` or `debug`
 			level, validLevel := levelStrings[strings.ToLower(sVal)]
 			if !validLevel {
 				logLevel, err := strconv.Atoi(sVal)
@@ -177,9 +177,9 @@ func stringToNewEncoderFuncHookFunc() mapstructure.DecodeHookFuncType {
 			var encoder crzap.NewEncoderFunc
 
 			switch val.(string) {
-			case "": // Encoder not configured; use default encoder
-				// TODO: Isn't the default encoder dependant on the development/production setting?
-				encoder = newJSONEncoder
+			case "":
+				// return nil if encoder is not set; controller-runtime sets the default value
+				return encoder, nil
 			case "console":
 				encoder = newConsoleEncoder
 			case "json":

--- a/pkg/zap/zap_test.go
+++ b/pkg/zap/zap_test.go
@@ -22,6 +22,8 @@ func TestSource(t *testing.T) {
 	RunSpecs(t, "Zap Log Suite")
 }
 
+const testMessage = "This is a test message"
+
 var _ = Describe("Zap log level flag options setup", func() {
 	var (
 		fs             flag.FlagSet
@@ -189,7 +191,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 			logOut := new(bytes.Buffer)
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info("This is a test message")
+			logger.Info(testMessage)
 
 			outRaw := logOut.Bytes()
 
@@ -208,7 +210,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := "This is a test message"
+			msg := testMessage
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
 			logger.Info(msg)
@@ -224,7 +226,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := "This is a test message"
+			msg := testMessage
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
 			logger.Info(msg)
@@ -238,7 +240,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 		It("Should default to json encoder when not set", func() {
 			logOut := new(bytes.Buffer)
 
-			msg := "This is a test message"
+			msg := testMessage
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
 			logger.Info(msg)
@@ -266,7 +268,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := "This is a test message"
+			msg := testMessage
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
 			logger.Info(msg)
@@ -284,7 +286,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := "This is a test message"
+			msg := testMessage
 
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
 			logger.Info(msg)

--- a/pkg/zap/zap_test.go
+++ b/pkg/zap/zap_test.go
@@ -210,10 +210,8 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := testMessage
-
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info(msg)
+			logger.Info(testMessage)
 
 			outRaw := logOut.String()
 			expectedPattern := `.+\tINFO\tThis is a test message\n`
@@ -226,10 +224,8 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := testMessage
-
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info(msg)
+			logger.Info(testMessage)
 
 			outRaw := logOut.Bytes()
 
@@ -239,10 +235,8 @@ var _ = Describe("Zap log level flag options setup", func() {
 		It("Should default to json encoder when not set", func() {
 			logOut := new(bytes.Buffer)
 
-			msg := testMessage
-
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info(msg)
+			logger.Info(testMessage)
 
 			outRaw := logOut.Bytes()
 
@@ -266,10 +260,8 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := testMessage
-
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info(msg)
+			logger.Info(testMessage)
 
 			outRaw := logOut.String()
 			expectedPattern := `.+\tINFO\tThis is a test message\n`
@@ -284,10 +276,8 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			logOut := new(bytes.Buffer)
 
-			msg := testMessage
-
 			logger := New(UseFlagOptions(&opts), crzap.WriteTo(logOut))
-			logger.Info(msg)
+			logger.Info(testMessage)
 
 			outRaw := logOut.String()
 			expectedPattern := `{\"level\":\"info\",\"ts\":\".+\",\"msg\":\"This is a test message\"}\n`

--- a/pkg/zap/zap_test.go
+++ b/pkg/zap/zap_test.go
@@ -233,8 +233,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			outRaw := logOut.Bytes()
 
-			res := map[string]interface{}{}
-			Expect(json.Unmarshal(outRaw, &res)).To(Succeed())
+			Expect(json.Valid(outRaw)).To(BeTrue())
 		})
 
 		It("Should default to json encoder when not set", func() {

--- a/pkg/zap/zap_test.go
+++ b/pkg/zap/zap_test.go
@@ -246,8 +246,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			outRaw := logOut.Bytes()
 
-			res := map[string]interface{}{}
-			Expect(json.Unmarshal(outRaw, &res)).To(Succeed())
+			Expect(json.Valid(outRaw)).To(BeTrue())
 		})
 
 		It("should PANIC when invalid encoder is supplied", func() {


### PR DESCRIPTION
This fixes a bug/TODO: the default encoder is dependant on dev-mode setting.