### PR TITLE
ci: promote release-please workflow permissions

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches:
       - main
-permissions: # added using https://github.com/step-security/secure-workflows
-  contents: read
+permissions:
+  contents: write # for google-github-actions/release-please-action to create release commit
+  pull-requests: write # for google-github-actions/release-please-action to create release PR
 jobs:
   release-please:
-    permissions:
-      contents: write # for google-github-actions/release-please-action to create release commit
-      pull-requests: write # for google-github-actions/release-please-action to create release PR
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Trying to see if promoting the release-please workflow permissions [according to docs](https://github.com/google-github-actions/release-please-action/compare/d3c71f9a0a55385580de793de58da057b3560862...e0b9d1885d92e9a93d5ce8656de60e3b806e542c) can fix the release CI issues.