### PR TITLE
chore: bump golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
-          version: v1.50.1
+          version: v1.52.2
   yaml-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To get Go 1.20 support in golangci-lint, we need to bump to a recent version.

@mikaelol Are you able add a Renovate config for this? For future upgrades?