### PR TITLE
chore(renovate): maintain golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
+          # renovate: datasource=go depName=github.com/golangci/golangci-lint
           version: v1.52.2
   yaml-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/statnett/controller-runtime-viper/issues/156