### PR TITLE
ci: don't run workflow requiring secrets in forks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == ‘statnett/controller-runtime-viper’ }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == ‘statnett/controller-runtime-viper’ }}
+    if: ${{ github.repository == 'statnett/controller-runtime-viper' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0


### PR DESCRIPTION
After resyncing the main branch in my fork, that triggered a workflow that will never work (in forks). GitHub has limited support for doing this, so the fix is a semi-hack inspired by https://github.com/orgs/community/discussions/26704.