### PR TITLE
ci: fix broken links to reusable workflows

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/lint-pr.yml@main
+    uses: statnett/github-workflows/.github/workflows/lint-pr.yml@main
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   trigger:
-    uses: statnett/workflows/.github/workflows/release-please.yml@main
+    uses: statnett/github-workflows/.github/workflows/release-please.yml@main
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
We have renamed the reusable GitHub workflow project and standardized on .yaml as file extensions. This updates what's needed to follow after.