### PR TITLE
ci: switch to Statnett default Renovate config and enable automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
+  "extends": ["github>statnett/renovate-config"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+    },
   ],
 }


### PR DESCRIPTION
Same config as proposed in https://github.com/statnett/image-scanner-operator/pull/638.