### PR TITLE
chore: upgrade Go mod requirements to Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/statnett/controller-runtime-viper
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Required to upgrade K8s dependencies. It would be nice if Renovate could suggest PRs like this, but it seems like it insists on a full Go version requirement - which is very uncommon and something I would like to avoid.