### PR TITLE
chore: remove toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/statnett/controller-runtime-viper
 
 go 1.22.0
 
-toolchain go1.22.2
-
 require (
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0


### PR DESCRIPTION
It seems like Renovate adds it, and I would prefer to avoid getting PRs for bumping the toolchain.