### PR TITLE
chore: make gosec linter happy

### DIFF
--- a/pkg/zap/zap.go
+++ b/pkg/zap/zap.go
@@ -141,11 +141,11 @@ func stringToLevelEnablerHookFunc() mapstructure.DecodeHookFuncType {
 			// Level string not successfully parsed as a valid zap level string. Trying to parse int level.
 			iVal, err := strconv.Atoi(sVal)
 			if err != nil {
-				return nil, fmt.Errorf("invalid log logLevel \"%s\"", val)
+				return nil, fmt.Errorf("invalid level value \"%s\"", val)
 			}
 
 			if iVal < int(zap.DebugLevel) || iVal > int(zap.FatalLevel) {
-				return nil, fmt.Errorf("invalid log logLevel \"%s\"", val)
+				return nil, fmt.Errorf("invalid level value \"%s\"", val)
 			}
 
 			// #nosec G115

--- a/pkg/zap/zap.go
+++ b/pkg/zap/zap.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
@@ -116,13 +115,6 @@ func newJSONEncoder(opts ...crzap.EncoderConfigOption) zapcore.Encoder {
 	return zapcore.NewJSONEncoder(encoderConfig)
 }
 
-var levelStrings = map[string]zapcore.Level{
-	"debug": zap.DebugLevel,
-	"info":  zap.InfoLevel,
-	"error": zap.ErrorLevel,
-	"panic": zap.PanicLevel,
-}
-
 func zapHook() mapstructure.DecodeHookFunc {
 	return mapstructure.ComposeDecodeHookFunc(
 		stringToLevelEnablerHookFunc(),
@@ -140,27 +132,26 @@ func stringToLevelEnablerHookFunc() mapstructure.DecodeHookFuncType {
 		sVal := val.(string)
 		if sVal == "" {
 			var v zapcore.LevelEnabler
-			// return nil if level is not set; controller-runtime sets the default value
+			// return nil if logLevel is not set; controller-runtime sets the default value
 			return &v, nil
 		}
 
-		// level supports setting of integer value > 0 in addition to `info`, `error` or `debug`
-		level, validLevel := levelStrings[strings.ToLower(sVal)]
-		if !validLevel {
-			logLevel, err := strconv.Atoi(sVal)
+		var logLevel zap.AtomicLevel
+		if err := logLevel.UnmarshalText([]byte(sVal)); err != nil {
+			iVal, err := strconv.Atoi(sVal)
 			if err != nil {
-				return nil, fmt.Errorf("invalid log level \"%s\"", val)
+				return nil, fmt.Errorf("invalid log logLevel \"%s\"", val)
 			}
 
-			if logLevel > 0 {
-				intLevel := -1 * logLevel
-				return zap.NewAtomicLevelAt(zapcore.Level(int8(intLevel))), nil
-			} else {
-				return nil, fmt.Errorf("invalid log level \"%s\"", val)
+			if iVal < int(zap.DebugLevel) || iVal > int(zap.FatalLevel) {
+				return nil, fmt.Errorf("invalid log logLevel \"%s\"", val)
 			}
+
+			// #nosec G115
+			logLevel = zap.NewAtomicLevelAt(zapcore.Level(int8(-iVal)))
 		}
 
-		return zap.NewAtomicLevelAt(level), nil
+		return logLevel, nil
 	}
 }
 

--- a/pkg/zap/zap.go
+++ b/pkg/zap/zap.go
@@ -132,12 +132,13 @@ func stringToLevelEnablerHookFunc() mapstructure.DecodeHookFuncType {
 		sVal := val.(string)
 		if sVal == "" {
 			var v zapcore.LevelEnabler
-			// return nil if logLevel is not set; controller-runtime sets the default value
+			// return nil if level is not set; controller-runtime sets the default value
 			return &v, nil
 		}
 
 		var logLevel zap.AtomicLevel
 		if err := logLevel.UnmarshalText([]byte(sVal)); err != nil {
+			// Level string not successfully parsed as a valid zap level string. Trying to parse int level.
 			iVal, err := strconv.Atoi(sVal)
 			if err != nil {
 				return nil, fmt.Errorf("invalid log logLevel \"%s\"", val)


### PR DESCRIPTION
This new goloangci-lint (gosec) error wasn't detected when upgrading golangci-lint. This resulted in all subsequent pipelines being borked. Hopefully, this minor change will fix the lint error.